### PR TITLE
Modified widths

### DIFF
--- a/src/components/instagram-embed.vue
+++ b/src/components/instagram-embed.vue
@@ -3,7 +3,7 @@
     class="instagram-media"
     data-instgrm-permalink="https://www.instagram.com/mistermonut/?utm_source=ig_embed&amp;utm_campaign=loading"
     data-instgrm-version="14"
-    style="width: 100%"
+    style="width: 100%; min-width: 0px !important"
   >
     <div>
       <a

--- a/src/sections/home/monut-title.vue
+++ b/src/sections/home/monut-title.vue
@@ -89,7 +89,11 @@ export default {
     svg {
       display: block;
       margin: auto;
-      height: 60vh;
+      height: 30vh;
+
+      @media screen and (min-width: 768px) {
+        height: 60vh;
+      }
     }
   }
 


### PR DESCRIPTION
I added a new width breakpoint for the monut-logo pic 😽 So now it look like this

![image](https://user-images.githubusercontent.com/40529597/219477303-052f2ef7-f43f-46b9-8b60-6d510c0b141b.png)

And I removed min-width from the instagram embed iframe that was making it also overflow on the page on smaller screens

![image](https://user-images.githubusercontent.com/40529597/219477383-4b78eca5-9d1a-4318-bf9c-919d2fe39183.png)

u can do whatever u want with this pr bestie <3 😸